### PR TITLE
Fix `component` language

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -736,9 +736,9 @@ function updateExample(doc, content) {
           <var>identifier</var>.</li>
         <li>For each <var>quad</var> in <var>quads</var>:
           <ol class="algorithm">
-            <li>For each <var>component</var> in <var>quad</var>, if <var>component</var>
-              is the <a>subject</a>, <a>object</a>, and
-              <a>graph name</a> and it is a
+            <li>For each <var>component</var> in <var>quad</var>, where <var>component</var>
+              is the <a>subject</a>, <a>object</a>, or
+              <a>graph name</a>, and it is a
               <a>blank node</a> that is not identified by
               <var>identifier</var>:
               <ol class="algorithm">


### PR DESCRIPTION
The `and` is erroneous, should be `or`. I also helped clarify the language here by replacing `if` with the more appropriate `where`.

This now translates to:
```js
if(quad.<component>.isBlankNode() && !quad.<component>.equals(identifier))
```